### PR TITLE
Bugfix for Printf ambiguity in OpenCascade and ROOT

### DIFF
--- a/source/EicToyModel.cc
+++ b/source/EicToyModel.cc
@@ -48,6 +48,7 @@ EicToyModel *EicToyModel::mInstance = 0;
 #define _CROSSING_ANGLE_DEFAULT_               ( 0.025)
 
 #ifdef _OPENCASCADE_
+#define Printf Printf_opencascade
 #include <gp_Pnt.hxx>
 #include <TopoDS_Solid.hxx>
 #include <BRepPrimAPI_MakeCylinder.hxx>
@@ -65,6 +66,7 @@ EicToyModel *EicToyModel::mInstance = 0;
 #include <BRepBuilderAPI_MakePolygon.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepPrimAPI_MakeRevol.hxx>
+#undef Printf
 #endif
 
 // ---------------------------------------------------------------------------------------

--- a/source/EtmDetector.cc
+++ b/source/EtmDetector.cc
@@ -12,6 +12,7 @@
 #define _GAP_WIDTH_         (  1.0)
 
 #ifdef _OPENCASCADE_
+#define Printf Printf_opencascade
 #include <gp_Pnt.hxx>
 #include <TopoDS_Solid.hxx>
 #include <BRepPrimAPI_MakeCylinder.hxx>
@@ -29,6 +30,7 @@
 #include <BRepBuilderAPI_MakePolygon.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepPrimAPI_MakeRevol.hxx>
+#undef Printf
 #endif
 
 #ifdef _ETM2GEANT_


### PR DESCRIPTION
Temporarily define the OpenCascade Printf so it is declared under a different name.

Unlikely that ROOT will be responsive to a fix on their end, and OpenCascade is arguably doing the right thing. This is what ROOT does at https://github.com/root-project/root/commit/c71e9ade417b5c1c9f3de614672a0060037df931.